### PR TITLE
Add options to list timezones by country or by region

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,32 @@ public static function form(Form $form): Form
 }
 ```
 
-All [Filament select field](https://filamentphp.com/docs/2.x/forms/fields#select) methods are available to use:
+To list only the timezones for a country, you can pass the country code to `->byCountry()` method. For example, to list only United States timezones:
+
+```php
+TimezoneSelect::make('timezone')
+    ->byCountry('US')
+```
+
+It's also possible to list the timezones for a region using `->byRegion()` method. You can specify a region with a [Region enum value](src/Enums/Region.php):
+
+```php
+use Tapp\FilamentTimezoneField\Enums\Region;
+
+TimezoneSelect::make('timezone')
+    ->byRegion(Region::Australia)
+```
+
+or you can use one of the [PHP's DateTimeZone predifined constants](https://www.php.net/manual/en/class.datetimezone.php):
+
+```php
+use DateTimeZone;
+
+TimezoneSelect::make('timezone')
+    ->byRegion(DateTimeZone::AUSTRALIA)
+```
+
+Also all [Filament select field](https://filamentphp.com/docs/2.x/forms/fields#select) methods are available to use:
 
 ```php
 use Tapp\FilamentTimezoneField\Forms\Components\TimezoneSelect;

--- a/src/Enums/Region.php
+++ b/src/Enums/Region.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tapp\FilamentTimezoneField\Enums;
+
+use DateTimeZone;
+use Filament\Support\Contracts\HasLabel;
+
+enum Region: int implements HasLabel
+{
+    case Africa = DateTimeZone::AFRICA;
+    case America = DateTimeZone::AMERICA;
+    case Antarctica = DateTimeZone::ANTARCTICA;
+    case Arctic = DateTimeZone::ARCTIC;
+    case Asia = DateTimeZone::ASIA;
+    case Atlantic = DateTimeZone::ATLANTIC;
+    case Australia = DateTimeZone::AUSTRALIA;
+    case Europe = DateTimeZone::EUROPE;
+    case Indian = DateTimeZone::INDIAN;
+    case Pacific = DateTimeZone::PACIFIC;
+
+    public function getLabel(): ?string
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
Add options to list timezones by country or by region:

By Country:

```php
TimezoneSelect::make('timezone')
    ->byCountry('US')
```

By region using a [Region enum value](src/Enums/Region.php):

```php
use Tapp\FilamentTimezoneField\Enums\Region;

TimezoneSelect::make('timezone')
    ->byRegion(Region::Australia)
```

By Region using  one of the [PHP's DateTimeZone predifined constants](https://www.php.net/manual/en/class.datetimezone.php):

```php
use DateTimeZone;

TimezoneSelect::make('timezone')
    ->byRegion(DateTimeZone::AUSTRALIA)
```