### PR TITLE
feat(column): add support for `DateTimeZone` instance

### DIFF
--- a/src/Concerns/CanFormatTimezone.php
+++ b/src/Concerns/CanFormatTimezone.php
@@ -15,24 +15,27 @@ trait CanFormatTimezone
         return $this->getTimezoneType().($offset ? sprintf('%+03d:%02d', $hours, $minutes) : '');
     }
 
-    protected function getFormattedTimezoneName(string $name): string
+    protected function getFormattedTimezoneName(string | DateTimeZone $name): string
     {
+        $name = is_string($name) ? $name : $name->getName();
+
         return str_replace(
             ['/', '_', 'St '],
             [', ', ' ', 'St. '],
-            $name
+            $name,
         );
     }
 
-    protected function getFormattedOffsetAndTimezone(string $offset, string $timezone): string
+    protected function getFormattedOffsetAndTimezone(string $offset, string | DateTimeZone $timezone): string
     {
         return sprintf('(%s) %s', $this->getFormattedOffset($offset), $this->getFormattedTimezoneName($timezone));
     }
 
-    public function getOffset(string $timezone): string
+    public function getOffset(string | DateTimeZone $timezone): string
     {
         $now = new DateTime('now', new DateTimeZone($this->getTimezoneType()));
+        $timezone = is_string($timezone) ? new DateTimeZone($timezone) : $timezone;
 
-        return $now->setTimezone(new DateTimeZone($timezone))->getOffset();
+        return $now->setTimezone($timezone)->getOffset();
     }
 }


### PR DESCRIPTION
This pull request adds support for timezone attributes that are casted to `DateTimeZone` instances.