### PR TITLE
Fix getTimezoneFromBrowser() causing "Component not found" on auth/SPA pages

### DIFF
--- a/src/Forms/Components/TimezoneSelect.php
+++ b/src/Forms/Components/TimezoneSelect.php
@@ -28,11 +28,23 @@ class TimezoneSelect extends Select
             // Only set browser timezone if the field is empty
             if (blank($this->getState())) {
                 $statePath = $this->getStatePath();
-
-                $livewire->js("
-                    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-                    \$wire.set('{$statePath}', timezone);
-                ");
+                $componentId = $livewire->getId();
+                // Defer to next tick so the component is in Livewire's registry (avoids
+                // "Component not found" on auth/SPA pages). Use Livewire.find(id) instead
+                // of $wire so we never look up the component during the initial effect run.
+                $livewire->js(
+                    '(function () {' .
+                    'var id = ' . json_encode($componentId) . ';' .
+                    'var statePath = ' . json_encode($statePath) . ';' .
+                    'var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;' .
+                    'var run = function () {' .
+                    '  var livewire = typeof Livewire !== "undefined" ? Livewire : window.Livewire;' .
+                    '  var c = livewire && livewire.find(id);' .
+                    '  if (c) c.set(statePath, timezone);' .
+                    '};' .
+                    'if (typeof queueMicrotask === "function") { queueMicrotask(run); } else { setTimeout(run, 0); }' .
+                    '})();'
+                );
             }
         });
 

--- a/src/Forms/Components/TimezoneSelect.php
+++ b/src/Forms/Components/TimezoneSelect.php
@@ -33,16 +33,16 @@ class TimezoneSelect extends Select
                 // "Component not found" on auth/SPA pages). Use Livewire.find(id) instead
                 // of $wire so we never look up the component during the initial effect run.
                 $livewire->js(
-                    '(function () {' .
-                    'var id = ' . json_encode($componentId) . ';' .
-                    'var statePath = ' . json_encode($statePath) . ';' .
-                    'var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;' .
-                    'var run = function () {' .
-                    '  var livewire = typeof Livewire !== "undefined" ? Livewire : window.Livewire;' .
-                    '  var c = livewire && livewire.find(id);' .
-                    '  if (c) c.set(statePath, timezone);' .
-                    '};' .
-                    'if (typeof queueMicrotask === "function") { queueMicrotask(run); } else { setTimeout(run, 0); }' .
+                    '(function () {'.
+                    'var id = '.json_encode($componentId).';'.
+                    'var statePath = '.json_encode($statePath).';'.
+                    'var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;'.
+                    'var run = function () {'.
+                    '  var livewire = typeof Livewire !== "undefined" ? Livewire : window.Livewire;'.
+                    '  var c = livewire && livewire.find(id);'.
+                    '  if (c) c.set(statePath, timezone);'.
+                    '};'.
+                    'if (typeof queueMicrotask === "function") { queueMicrotask(run); } else { setTimeout(run, 0); }'.
                     '})();'
                 );
             }


### PR DESCRIPTION
## Problem
`getTimezoneFromBrowser()` uses `$livewire->js()` to run `$wire.set(statePath, timezone)` during form state hydration. On Livewire 4 auth pages (e.g. Filament register), that can run before the component is in Livewire's client-side registry, causing:
- **"Component not found"** in the console
- Broken password-field blur/validation and other form behavior

## Solution
- Defer the timezone logic to the next JavaScript tick via `queueMicrotask` (or `setTimeout(..., 0)` as fallback).
- Resolve the component with `Livewire.find(componentId)` in that deferred callback instead of using `$wire` during the initial effect run.
- Pass the component ID from PHP (`$livewire->getId()`) so we never look up the component until after it is registered.

Behavior is unchanged for users: the timezone field still auto-fills from `Intl.DateTimeFormat().resolvedOptions().timeZone` when empty. Only the timing of the lookup is different.

## Testing
Verified on a Filament 5 / Livewire 4 app with the register page: no more "Component not found", password blur works, and timezone still populates from the browser.

Made with [Cursor](https://cursor.com)