### PR TITLE
Chore: Allow symfony/intl ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/TappNetwork/filament-timezone-field"
     },
     "require": {
-        "symfony/intl": "^7.0"
+        "symfony/intl": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Details

This PR allows to install symfony/intl in version 8.
