### PR TITLE
Use Node 24-compatible GitHub Actions

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -8,7 +8,7 @@ jobs:
   phplint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - name: "laravel-pint"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.target_commitish }}
 


### PR DESCRIPTION
## Summary
- bump GitHub Actions workflow dependencies to Node 24-compatible majors
- update checkout/composer/cache/artifact actions where present

## Verification
- CI will verify this workflow-only change on the PR
