### PR TITLE
Support Pest 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,8 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "pestphp/pest": "^4.0|^5.0"
+    }
 }


### PR DESCRIPTION
## Summary
- Allow Pest 5 in composer dev constraints.
- Include matching Pest plugin constraints where this package uses Pest plugins.
- Keep existing Pest version support in place for current stable installs.

## Verification
- `composer validate --no-check-publish`
- `composer update --dry-run`

Note: Pest 5 is currently available to Composer as a dev line, so this prepares the package constraints while preserving current stable Pest 4 resolution.
